### PR TITLE
Missing include cstring

### DIFF
--- a/VideoOutput.cpp
+++ b/VideoOutput.cpp
@@ -7,6 +7,9 @@
     #include "Globals.hpp"
     #include "Logging.hpp"
     
+    // include C/C++ headers
+    #include <cstring>          // [ ANSI C ] Strings
+    
     // declare used namespaces
     using namespace std;
     using namespace V32;


### PR DESCRIPTION
I tried to build the core on Linux but I was running this issue

<details>
  <summary>Log</summary>

```
mkdir build
cd build/
cmake ..
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenGL: /usr/lib/libOpenGL.so   
-- * OPENGL found
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/vircon32-libretro/build
```

```
make -j$(nproc)
[ 12%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/ExternalInterfaces.cpp.o
[ 12%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32CartridgeController.cpp.o
[ 20%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32Console.cpp.o
[ 16%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/AuxiliaryFunctions.cpp.o
[ 24%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32CPU.cpp.o
[ 16%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32Buses.cpp.o
[ 28%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32CPUProcessors.cpp.o
[ 32%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32GamepadController.cpp.o
[ 36%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32GPU.cpp.o
[ 40%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32GPUWriters.cpp.o
[ 44%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32Memory.cpp.o
[ 48%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32MemoryCardController.cpp.o
[ 52%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32NullController.cpp.o
[ 56%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32RNG.cpp.o
[ 60%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32SPU.cpp.o
[ 64%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32SPUWriters.cpp.o
[ 68%] Building CXX object ConsoleLogic/CMakeFiles/V32ConsoleLogic.dir/V32Timer.cpp.o
[ 72%] Linking CXX static library libV32ConsoleLogic.a
[ 72%] Built target V32ConsoleLogic
[ 80%] Building CXX object CMakeFiles/vircon32_libretro.dir/Globals.cpp.o
[ 80%] Building CXX object CMakeFiles/vircon32_libretro.dir/VideoOutput.cpp.o
[ 84%] Building CXX object CMakeFiles/vircon32_libretro.dir/libretro.cpp.o
[ 88%] Building CXX object CMakeFiles/vircon32_libretro.dir/Logging.cpp.o
[ 92%] Building C object CMakeFiles/vircon32_libretro.dir/glsym/glsym_gl.c.o
[ 96%] Building C object CMakeFiles/vircon32_libretro.dir/glsym/rglgen.c.o
/tmp/vircon32-libretro/VideoOutput.cpp: In member function 'void VideoOutput::DrawTexturedQuad(const V32::GPUQuad&)':
/tmp/vircon32-libretro/VideoOutput.cpp:501:5: error: 'memcpy' was not declared in this scope
  501 |     memcpy( QuadPositionCoords, Quad.VertexPositions, 8 * sizeof( float ) );
      |     ^~~~~~
/tmp/vircon32-libretro/VideoOutput.cpp:9:1: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
    8 |     #include "Logging.hpp"
  +++ |+#include <cstring>
    9 | 
make[2]: *** [CMakeFiles/vircon32_libretro.dir/build.make:118: CMakeFiles/vircon32_libretro.dir/VideoOutput.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/vircon32_libretro.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

```
</details> 

Also I have to add `cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON`  otherwise we got this linking issue

```
[100%] Linking CXX shared library vircon32_libretro.so
/usr/bin/ld: ConsoleLogic/libV32ConsoleLogic.a(V32Timer.cpp.o): warning: relocation against `_ZTVN3V328V32TimerE' in read-only section `.text'
/usr/bin/ld: ConsoleLogic/libV32ConsoleLogic.a(V32Console.cpp.o): relocation R_X86_64_PC32 against symbol `_ZN3V329Callbacks7LogLineB5cxx11E' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/vircon32_libretro.dir/build.make:181: vircon32_libretro.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/vircon32_libretro.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```