### PR TITLE
libretro: add webOS to CMakeLists/ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,6 +67,11 @@ include:
   # PS2, PSVita, GameCube, Wii and WiiU: Omitted
   # (they don't seem to support standard OpenGL)
 
+  #################################### MISC ##################################
+  # webOS (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -181,3 +186,10 @@ libretro-build-tvos-arm64:
 
 # PS2, PSVita, GameCube, Wii and WiiU: Omitted
 # (they don't seem to support standard OpenGL)
+
+#################################### MISC ####################################
+# webOS
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
+    - .core-defs-gles2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ embed_binaries(EmbeddedAssets
         NAME "StandardBios"
         PATH "Assets/StandardBios.v32")
 
+if(CMAKE_CXX_COMPILER MATCHES "webos" OR
+   CMAKE_CXX_COMPILER MATCHES "starfish")
+	set(WEBOS ON)
+endif()
+
 # -----------------------------------------------------
 #   FINDING PROJECT DEPENDENCIES
 
@@ -53,6 +58,10 @@ elseif(ANDROID_ABI)
 # for IOS we will also link against GLES3, but in a different way
 elseif(IOS)
     set(ENABLE_OPENGLES3 1)
+
+elseif(WEBOS)
+    set(ENABLE_OPENGLES2 1)
+    set(OPENGL_LIBRARIES GLESv2)
 
 # for other systems we need to search for OpenGL
 else()


### PR DESCRIPTION
Note as per https://github.com/vircon32/vircon32-libretro/issues/17 needs embed-binaries.cmake updating from their repo for it to build.

Thanks :+1: 